### PR TITLE
Documentation Building

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,24 @@ jobs:
             pip install codecov
             codecov
 
+
+  publish-docs:
+    executor: python38-executor
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: install aws cli
+          command: |
+            curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+            unzip awscliv2.zip
+            sudo ./aws/install
+      - run:
+          name: Build and release docs
+          command: |
+            source venv/bin/activate
+            make publish-docs
+
 workflows:
   main:
     jobs:
@@ -86,5 +104,17 @@ workflows:
           requires:
             - setup-environment
       - code-coverage:
+          requires:
+            - setup-environment
+
+  update-docs:
+    jobs:
+      - approve-update:
+          type: approval
+      - setup-environment:
+          requires:
+            - approve-update
+      - publish-docs:
+          context: aws
           requires:
             - setup-environment

--- a/Makefile
+++ b/Makefile
@@ -66,5 +66,9 @@ docs: ## generate Sphinx HTML documentation, including API docs
 	sphinx-build -b html docs/source/ docs/build/
 	$(BROWSER) docs/build/index.html
 
+publish-docs:
+	$(MAKE) docs
+	aws s3 sync ./docs/build  s3://docs-coz/neo3/mamba --acl public-read
+
 type: ## perform static type checking using mypy
 	mypy neo3/


### PR DESCRIPTION
This PR implements a new make method to build and publish sphinx documentation to the neo3 mamba project bucket.  It also adds a circleCI workflow to automated the publishing.  The workflow is run on manual approval.